### PR TITLE
 Adds the Chocolatey package as a way to install Tachidesk-JUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Double-click on the jar file or run `java -jar Tachidesk-JUI-os-arch-X.Y.Z.jar` 
 ### Windows (x64, Java 8+ required for server)
 #### Installer
 Download the latest msi release from [the releases section][release] (Or from [the preview releases][preview]).
+#### [Chocolatey](https://community.chocolatey.org/packages/tachidesk)
+`choco install tachidesk`
 #### Winget
 `winget install tachidesk-jui`
 #### Scoop


### PR DESCRIPTION
Hi Tachidesk-JUI devs,

I have created this Pull Request because I have resolved this [request for a Chocolatey package](https://github.com/chocolatey-community/chocolatey-package-requests/issues/1041) and now, we can install **tachidesk** using [Chocolatey](https://community.chocolatey.org/packages/tachidesk).

For now, only the latest version (`1.3.0`) is available on Chocolatey. When new versions will be released, they will, then, be added to the Chocolatey package for users to enjoy. :slightly_smiling_face: 

